### PR TITLE
Updated JDK versions in Cloud Shell/Code Editor

### DIFF
--- a/java-samples/graalvmee-java-hello-world/README-check-version-env-vars.md
+++ b/java-samples/graalvmee-java-hello-world/README-check-version-env-vars.md
@@ -6,12 +6,12 @@
     csruntimectl java list
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+    * graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+      oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Confirm the environment variable `JAVA_HOME` is set correctly:
@@ -35,7 +35,7 @@
     The output should be similar to:
 
     ```shell
-    /usr/lib64/graalvm/graalvm22-ee-java17/bin/:/ggs_client/usr/bin: ...
+    /usr/lib64/graalvm/graalvm22-ee-java17/bin/:...
     ```
 
 5. Confirm the `java` version:
@@ -44,12 +44,12 @@
     java -version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    java version "17.0.4.1" 2022-08-18 LTS
-    Java(TM) SE Runtime Environment GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08)
-    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08, mixed mode, sharing)
+    java version "17.0.5" 2022-10-18 LTS
+    Java(TM) SE Runtime Environment GraalVM EE 22.3.0 (build 17.0.5+9-LTS-jvmci-22.3-b07)
+    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.3.0 (build 17.0.5+9-LTS-jvmci-22.3-b07, mixed mode, sharing)
     ```
 
 6. Confirm the `native-image` version:
@@ -58,10 +58,10 @@
     native-image --version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    GraalVM 22.2.0.1 Java 17 EE (Java Version 17.0.4.1+1-LTS-jvmci-22.2-b08)
+    GraalVM 22.3.0 Java 17 EE (Java Version 17.0.5+9-LTS-jvmci-22.3-b07)
     ```
 
 7. Confirm the `maven` version and `Java` used:
@@ -70,14 +70,14 @@
     mvn --version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
     Apache Maven 3.6.1 (Red Hat 3.6.1-6.3)
     Maven home: /opt/rh/rh-maven36/root/usr/share/maven
-    Java version: 17.0.4.1, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
+    Java version: 17.0.5, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
     Default locale: en_US, platform encoding: UTF-8
-    OS name: "linux", version: "4.14.35-2047.515.3.el7uek.x86_64", arch: "amd64", family: "unix"
+    OS name: "linux", version: "4.14.35-2047.516.2.2.el7uek.x86_64", arch: "amd64", family: "unix"
     ```
 
 Continue to **[Step 4: Setup Project and Run](./README.md#step-4-setup-project-and-run)**

--- a/java-samples/graalvmee-java-hello-world/README.md
+++ b/java-samples/graalvmee-java-hello-world/README.md
@@ -35,21 +35,21 @@ Code Editor's direct integration with Cloud Shell allows you access to the Graal
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+      graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+    * oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4.1
+    csruntimectl java set graalvmeejdk-17
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.1.
+    The current managed java version is set to graalvmeejdk-17.
     ```
 
 ## Step 3: [OPTIONAL] Confirm Software Version and Environment Variables
@@ -99,147 +99,46 @@ This step is optional - [Check software version and environment variables](./REA
     Hello World!
     ```
 
-4. Let's use GraalVM Native Image to produce a native executable.
+4. **Option 1: Quick Build enabled**: Let's use GraalVM Native Image to produce a native executable with the `Quick Build` option.
 
-    4.1) **Option 1: Quick Build enabled**
-
-    To enable `Quick Build`, open [pom.xml](pom.xml) in the Code Editor and uncomment the line shown:
+    4.1) To enable `Quick Build`, open [pom.xml](pom.xml) in the Code Editor and uncomment the line shown:
 
     ```
     <buildArg>-Ob</buildArg>
     ```
 
-    Run the Native Image build to generate a native executable:
+    4.2) Run the Native Image build to generate a native executable:
 
     ```shell
-    export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
-
     mvn clean -Pnative -DskipTests package
     ```
 
-    With **Quick Build enabled** in the pom.xml, the output should be similar to:
+    4.3) Run the native executable using:
 
-    ```
-    ...
-    You enabled -Ob for this image build. This will configure some optimizations to reduce image build time.
-    ...
-    ========================================================================================================================
-    GraalVM Native Image: Generating 'my-app' (executable)...
-    ========================================================================================================================
-    [1/7] Initializing...                                                                                   (11.0s @ 0.21GB)
-    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
-    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
-    C compiler: gcc (redhat, x86_64, 11.2.1)
-    Garbage collector: Serial GC
-    [2/7] Performing analysis...  [*****]                                                                   (19.3s @ 0.69GB)
-    1,819 (62.34%) of  2,918 classes reachable
-    1,662 (46.88%) of  3,545 fields reachable
-    7,638 (37.13%) of 20,573 methods reachable
-        17 classes,     0 fields, and   254 methods registered for reflection
-        49 classes,    32 fields, and    48 methods registered for JNI access
-        4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                               (2.8s @ 0.93GB)
-    [4/7] Parsing methods...      [**]                                                                       (3.0s @ 0.35GB)
-    [5/7] Inlining methods...     [***]                                                                      (1.8s @ 0.60GB)
-    [6/7] Compiling methods...    [***]                                                                     (10.8s @ 0.75GB)
-    [7/7] Creating image...                                                                                  (2.0s @ 0.94GB)
-    1.78MB (42.86%) for code area:     4,433 compilation units
-    2.23MB (53.52%) for image heap:   36,676 objects and 1 resources
-    154.52KB ( 3.63%) for other data
-    4.16MB in total
-    ------------------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                               Top 10 object types in image heap:
-    208.78KB com.oracle.svm.jni                                 373.74KB byte[] for code metadata
-    184.72KB java.lang                                          316.52KB byte[] for java.lang.String
-    168.31KB com.oracle.svm.core.code                           267.37KB java.lang.Class
-    144.00KB java.util                                          263.25KB java.lang.String
-    104.54KB com.oracle.svm.core.genscavenge                    213.14KB byte[] for general heap data
-    80.73KB java.util.concurrent                               111.71KB char[]
-    64.87KB java.lang.invoke                                    71.05KB com.oracle.svm.core.hub.DynamicHubCompanion
-    52.95KB java.math                                           68.35KB byte[] for reflection metadata
-    44.58KB com.oracle.svm.jni.functions                        50.34KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    40.69KB java.io                                             44.95KB java.util.HashMap$Node[]
-    700.72KB for 99 more packages                               346.11KB for 478 more object types
-    ------------------------------------------------------------------------------------------------------------------------
-                            1.3s (2.4% of total time) in 14 GCs | Peak RSS: 1.62GB | CPU load: 1.74
-    ------------------------------------------------------------------------------------------------------------------------
-    Produced artifacts:
-    /home/user_graal/graalvmee-java-hello-world/target/my-app (executable)
-    /home/user_graal/graalvmee-java-hello-world/target/my-app.build_artifacts.txt (txt)
-    ========================================================================================================================
-    Finished generating 'my-app' in 52.8s.
-    ...
+    ```shell
+    ./target/my-app
     ```
 
-    4.2) **Option 2: Quick Build disabled** 
+    The output should be similar to:
+    ```
+    Hello World!
+    ```
     
-    To disable `Quick Build`, open [pom.xml](pom.xml) in the Code Editor and comment the line shown:  
+5. **Option 2: Quick Build disabled** Let's use GraalVM Native Image to produce a native executable without the `Quick Build` option.
+    
+    5.1) To disable `Quick Build`, open [pom.xml](pom.xml) in the Code Editor and comment the line shown:  
 
     ```
     <!-- <buildArg>-Ob</buildArg> -->
     ```
 
-    Run the Native Image build to generate a native executable:
+    5.2) Run the Native Image build to generate a native executable:
 
     ```shell
-    export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
-
     mvn clean -Pnative -DskipTests package
     ```
 
-    With **Quick Build disabled** in the pom.xml, the output should be similar to:
-
-    ```
-    ...
-    ========================================================================================================================
-    GraalVM Native Image: Generating 'my-app' (executable)...
-    ========================================================================================================================
-    [1/7] Initializing...                                                                                   (10.8s @ 0.21GB)
-    Version info: 'GraalVM 22.2.0.1 Java 17 EE'
-    Java version info: '17.0.4.1+1-LTS-jvmci-22.2-b08'
-    C compiler: gcc (redhat, x86_64, 11.2.1)
-    Garbage collector: Serial GC
-    [2/7] Performing analysis...  [*****]                                                                   (19.3s @ 0.74GB)
-    1,858 (61.54%) of  3,019 classes reachable
-    1,698 (47.23%) of  3,595 fields reachable
-    7,633 (36.19%) of 21,094 methods reachable
-        17 classes,     0 fields, and   254 methods registered for reflection
-        49 classes,    32 fields, and    48 methods registered for JNI access
-        4 native libraries: dl, pthread, rt, z
-    [3/7] Building universe...                                                                               (2.8s @ 1.00GB)
-    [4/7] Parsing methods...      [**]                                                                       (2.8s @ 0.44GB)
-    [5/7] Inlining methods...     [***]                                                                      (1.7s @ 0.70GB)
-    [6/7] Compiling methods...    [*******]                                                                 (45.5s @ 2.32GB)
-    [7/7] Creating image...                                                                                  (2.2s @ 2.53GB)
-    2.50MB (49.18%) for code area:     3,714 compilation units
-    2.43MB (47.88%) for image heap:   36,993 objects and 1 resources
-    152.73KB ( 2.93%) for other data
-    5.08MB in total
-    ------------------------------------------------------------------------------------------------------------------------
-    Top 10 packages in code area:                               Top 10 object types in image heap:
-    299.87KB java.lang                                          508.47KB byte[] for code metadata
-    193.82KB com.oracle.svm.jni                                 319.17KB byte[] for java.lang.String
-    190.45KB java.util                                          272.45KB java.lang.Class
-    155.80KB com.oracle.svm.core.code                           265.22KB java.lang.String
-    118.87KB com.oracle.svm.core.genscavenge                    214.75KB byte[] for general heap data
-    111.77KB java.util.concurrent                               111.71KB char[]
-    75.68KB java.lang.invoke                                    72.58KB com.oracle.svm.core.hub.DynamicHubCompanion
-    73.33KB java.math                                           69.43KB byte[] for reflection metadata
-    71.31KB jdk.proxy4                                          51.22KB c.o.svm.core.hub.DynamicHub$ReflectionMetadata
-    68.17KB com.oracle.svm.core                                 44.95KB java.util.HashMap$Node[]
-    1.15MB for 96 more packages                               349.00KB for 474 more object types
-    ------------------------------------------------------------------------------------------------------------------------
-                            1.4s (1.6% of total time) in 17 GCs | Peak RSS: 2.94GB | CPU load: 1.76
-    ------------------------------------------------------------------------------------------------------------------------
-    Produced artifacts:
-    /home/user_graal/graalvmee-java-hello-world/target/my-app (executable)
-    /home/user_graal/graalvmee-java-hello-world/target/my-app.build_artifacts.txt (txt)
-    ========================================================================================================================
-    Finished generating 'my-app' in 1m 27s.
-    ...
-    ```
-
-5. Run the native executable using:
+    5.3) Run the native executable using:
 
     ```shell
     ./target/my-app
@@ -257,7 +156,7 @@ This step is optional - [Check software version and environment variables](./REA
 ## Contributors
 * Author: Sachin Pikle
 * Collaborators: Ashok Raja CM
-* Last updated: October 2022
+* Last updated: November 2022
 
 ## Contributing
 This project is open source.  Please submit your contributions by forking this repository and submitting a pull request!  Oracle appreciates any contributions that are made by the open source community.

--- a/java-samples/graalvmee-java-hello-world/pom.xml
+++ b/java-samples/graalvmee-java-hello-world/pom.xml
@@ -83,6 +83,8 @@
                 <buildArg>--verbose</buildArg>
                 <!-- For Quick Build (22.1+) -->
 								<buildArg>-Ob</buildArg>
+                <!-- To generate the Native Image build output JSON (22.3+) -->
+                <buildArg>-H:BuildOutputJSONFile=build.json</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/java-samples/graalvmee-java-micronaut-hello-rest/README-check-version-env-vars.md
+++ b/java-samples/graalvmee-java-micronaut-hello-rest/README-check-version-env-vars.md
@@ -6,12 +6,12 @@
     csruntimectl java list
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    * graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-      openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+    * graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+      oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Confirm the environment variable `JAVA_HOME` is set correctly:
@@ -35,7 +35,7 @@
     The output should be similar to:
 
     ```shell
-    /usr/lib64/graalvm/graalvm22-ee-java17/bin/:/ggs_client/usr/bin: ...
+    /usr/lib64/graalvm/graalvm22-ee-java17/bin/:...
     ```
 
 4. Confirm the `java` version:
@@ -44,12 +44,12 @@
     java -version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    java version "17.0.4.1" 2022-08-18 LTS
-    Java(TM) SE Runtime Environment GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08)
-    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.2.0.1 (build 17.0.4.1+1-LTS-jvmci-22.2-b08, mixed mode, sharing)
+    java version "17.0.5" 2022-10-18 LTS
+    Java(TM) SE Runtime Environment GraalVM EE 22.3.0 (build 17.0.5+9-LTS-jvmci-22.3-b07)
+    Java HotSpot(TM) 64-Bit Server VM GraalVM EE 22.3.0 (build 17.0.5+9-LTS-jvmci-22.3-b07, mixed mode, sharing)
     ```
 
 5. Confirm the `native-image` version:
@@ -58,10 +58,10 @@
     native-image --version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
-    GraalVM 22.2.0.1 Java 17 EE (Java Version 17.0.4.1+1-LTS-jvmci-22.2-b08)
+    GraalVM 22.3.0 Java 17 EE (Java Version 17.0.5+9-LTS-jvmci-22.3-b07)
     ```
 
 6. Confirm the `maven` version and `Java` used:
@@ -70,14 +70,14 @@
     mvn --version
     ```
 
-    The output should be similar to:
+    The output should be similar to (versions may vary):
 
     ```shell
     Apache Maven 3.6.1 (Red Hat 3.6.1-6.3)
     Maven home: /opt/rh/rh-maven36/root/usr/share/maven
-    Java version: 17.0.4.1, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
+    Java version: 17.0.5, vendor: Oracle Corporation, runtime: /usr/lib64/graalvm/graalvm22-ee-java17
     Default locale: en_US, platform encoding: UTF-8
-    OS name: "linux", version: "4.14.35-2047.515.3.el7uek.x86_64", arch: "amd64", family: "unix"
+    OS name: "linux", version: "4.14.35-2047.516.2.2.el7uek.x86_64", arch: "amd64", family: "unix"
     ```
 
 Continue to **[Step 4: Setup Project and Run](./README.md#step-4-setup-project-and-run)**

--- a/java-samples/graalvmee-java-micronaut-hello-rest/README.md
+++ b/java-samples/graalvmee-java-micronaut-hello-rest/README.md
@@ -42,21 +42,21 @@ Code Editor's direct integration with Cloud Shell allows you access to the Graal
     The output should be similar to:
 
     ```shell
-      graalvmeejdk-17.0.4.1                                         /usr/lib64/graalvm/graalvm22-ee-java17
-    * openjdk-11.0.16.1                        /usr/lib/jvm/java-11-openjdk-11.0.16.1.1-1.0.1.el7_9.x86_64
-      openjdk-1.8.0.345                       /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.345.b01-1.el7_9.x86_64
+      graalvmeejdk-17                                               /usr/lib64/graalvm/graalvm22-ee-java17
+    * oraclejdk-1.8                                                           /usr/java/jdk1.8.0_351-amd64
+      oraclejdk-11                                                                   /usr/java/jdk-11.0.17
     ```
 
 2. Select GraalVM as the current JDK:
 
     ```shell
-    csruntimectl java set graalvmeejdk-17.0.4.1
+    csruntimectl java set graalvmeejdk-17
     ```
 
     The output should be similar to:
 
     ```shell
-    The current managed java version is set to graalvmeejdk-17.0.4.1.
+    The current managed java version is set to graalvmeejdk-17.
     ```
 
 
@@ -170,7 +170,7 @@ This step is optional - [Check software version and environment variables](./REA
 ## Contributors
 * Author: Sachin Pikle
 * Collaborators: Ashok Raja CM
-* Last updated: October 2022
+* Last updated: November 2022
 
 ## Contributing
 This project is open source.  Please submit your contributions by forking this repository and submitting a pull request!  Oracle appreciates any contributions that are made by the open source community.

--- a/java-samples/graalvmee-java-micronaut-hello-rest/pom.xml
+++ b/java-samples/graalvmee-java-micronaut-hello-rest/pom.xml
@@ -100,6 +100,8 @@
             <buildArg>--verbose</buildArg>
             <!-- For Quick Build (22.1+) -->
             <buildArg>-Ob</buildArg>
+            <!-- To generate the Native Image build output JSON (22.3+) -->
+            <buildArg>-H:BuildOutputJSONFile=build.json</buildArg>
           </buildArgs>
         </configuration>
       </plugin>

--- a/java-samples/graalvmee-java-micronaut-hello-rest/pom.xml
+++ b/java-samples/graalvmee-java-micronaut-hello-rest/pom.xml
@@ -10,14 +10,14 @@
   <parent>
     <groupId>io.micronaut</groupId>
     <artifactId>micronaut-parent</artifactId>
-    <version>3.7.1</version>
+    <version>3.7.3</version>
   </parent>
 
   <properties>
     <packaging>jar</packaging>
     <jdk.version>17</jdk.version>
     <release.version>17</release.version>
-    <micronaut.version>3.7.1</micronaut.version>
+    <micronaut.version>3.7.3</micronaut.version>
     <micronaut.runtime>netty</micronaut.runtime>
     <exec.mainClass>com.example.Application</exec.mainClass>
   </properties>


### PR DESCRIPTION
Changes:
1. Updated JDK versions in Cloud Shell/Code Editor
2. Save Native Image build output JSON
3. Using Micronaut 3.7.3